### PR TITLE
이미지 모아보기에서 큰 포스터가 확대되서 보이는 문제 해결

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-10-17T00:02:13.508501Z">
+        <DropdownSelection timestamp="2024-10-24T04:37:45.522843Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/ssh/.android/avd/Pixel_3a_API_35.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CR60PWCMV" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -326,17 +326,6 @@
           <option name="screenX" value="1080" />
           <option name="screenY" value="2424" />
         </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
-          <option name="api" value="29" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="x1q" />
-          <option name="id" value="x1q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy S20" />
-          <option name="screenDensity" value="480" />
-          <option name="screenX" value="1440" />
-          <option name="screenY" value="3200" />
-        </PersistentDeviceSelectionData>
       </list>
     </option>
   </component>

--- a/app/src/main/java/com/api/palette/data/socket/BaseResponseMessage.kt
+++ b/app/src/main/java/com/api/palette/data/socket/BaseResponseMessage.kt
@@ -21,6 +21,7 @@ sealed class BaseResponseMessage {
         val roomId: Int,
         val userId: Int,
         val isAi: Boolean,
+        val regenScope: Boolean,
         val promptId: String?,
     ) : BaseResponseMessage()
 

--- a/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
@@ -86,7 +86,7 @@ class ChattingFragment(
                     viewLifecycleOwner.lifecycleScope.launch {
                         val m = async {
                             while (isFirst && !firstMsgReceived && chatList.isEmpty()) {
-                                if (System.currentTimeMillis() - connection > 3000) {
+                                if (System.currentTimeMillis() - connection > 4000) {
                                     delay(500L)
                                     loadChatData()
                                 }

--- a/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
@@ -86,7 +86,7 @@ class ChattingFragment(
                     viewLifecycleOwner.lifecycleScope.launch {
                         val m = async {
                             while (isFirst && !firstMsgReceived && chatList.isEmpty()) {
-                                if (System.currentTimeMillis() - connection > 4000) {
+                                if (System.currentTimeMillis() - connection > 2000) {
                                     delay(500L)
                                     loadChatData()
                                 }
@@ -477,6 +477,7 @@ class ChattingFragment(
 
             val numberPicker = NumberPicker(context).apply {
                 wrapSelectorWheel = true
+                descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
 
                 selectableQuestion?.choices?.let { choices ->
                     minValue = 0

--- a/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
@@ -398,7 +398,7 @@ class ChattingFragment(
             if (position == "0") {
                 positionLabel.visibility = View.GONE
                 currentPositionText.text = "그리는 중.."
-                (positionBox.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin = 10
+                (positionBox.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin = 20
             }
         }
     }

--- a/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
@@ -758,7 +758,8 @@ class ChattingFragment(
                 dialog.dismiss()
             }
         }
-        dialog.setCancelable(false)
+        dialog.setCancelable(true)
+
         dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         dialog.show()
     }

--- a/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/chat/ChattingFragment.kt
@@ -398,6 +398,7 @@ class ChattingFragment(
             if (position == "0") {
                 positionLabel.visibility = View.GONE
                 currentPositionText.text = "그리는 중.."
+                (positionBox.layoutParams as? ViewGroup.MarginLayoutParams)?.bottomMargin = 10
             }
         }
     }

--- a/app/src/main/java/com/api/palette/ui/main/create/room/CreateMediaFragment.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/room/CreateMediaFragment.kt
@@ -70,7 +70,7 @@ class CreateMediaFragment : Fragment() {
         workAdapter.itemClickListener = object : CreateMediaAdapter.OnItemClickListener {
             override fun onItemClick(position: Int) {
                 if (isDeleting) return // item 삭제 중 삭호작용 막음 -> block index error
-                startChatting(roomList.data[position].id, roomList.data[position].title.toString())
+                startChatting(itemList[position].id, itemList[position].title.toString())
             }
 
             override fun onItemLongClick(position: Int) {
@@ -89,8 +89,9 @@ class CreateMediaFragment : Fragment() {
                         binding.roomListEmptyText.visibility = View.VISIBLE
                     } else {
                         binding.roomListEmptyText.visibility = View.GONE
+                        val list = roomList.data.reversed()
                         itemList.clear()
-                        itemList.addAll(roomList.data)
+                        itemList.addAll(list)
 
                         initWorkAdapter()
 

--- a/app/src/main/java/com/api/palette/ui/main/create/room/adapter/CreateMediaAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/create/room/adapter/CreateMediaAdapter.kt
@@ -49,7 +49,7 @@ class CreateMediaAdapter(
                     isLongClick = false // 초기화
                     handler.postDelayed({
                         isLongClick = true // 롱 클릭 상태로 변경
-                        itemClickListener.onItemLongClick(position)
+                        itemClickListener.onItemLongClick(holder.bindingAdapterPosition)
                     }, 600)
                 }
                 MotionEvent.ACTION_UP -> {
@@ -58,7 +58,7 @@ class CreateMediaAdapter(
 
                     // 롱 클릭 상태가 아닐 경우에만 클릭 이벤트 처리
                     if (!touchHandled && !isLongClick) {
-                        itemClickListener.onItemClick(position)
+                        itemClickListener.onItemClick(holder.bindingAdapterPosition)
                     }
                 }
                 MotionEvent.ACTION_CANCEL -> {

--- a/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
@@ -110,7 +110,7 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
 
         val imageView = dialogView.findViewById<SubsamplingScaleImageView>(R.id.imageView)
 
-        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE)
+        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_CROP)
 
         Glide.with(context)
             .asBitmap()

--- a/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
@@ -106,7 +106,8 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
 
     private fun showZoomedImageDialog(context: Context, imageUrl: String) {
         val dialog = Dialog(context)
-        val dialogView = LayoutInflater.from(context).inflate(R.layout.item_image, null)
+
+        val dialogView = LayoutInflater.from(context).inflate(R.layout.item_zoomed_image_dialog, null)
 
         val imageView = dialogView.findViewById<SubsamplingScaleImageView>(R.id.imageView)
 

--- a/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
@@ -110,7 +110,7 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
 
         val imageView = dialogView.findViewById<SubsamplingScaleImageView>(R.id.imageView)
 
-        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE) // 스케일링 변경
+        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE)
 
         Glide.with(context)
             .asBitmap()
@@ -128,12 +128,14 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
         dialog.setContentView(dialogView)
         dialog.show()
 
+        val screenHeight = context.resources.displayMetrics.heightPixels
+        val dialogHeight = (screenHeight * 0.8).toInt()
+
         dialog.window?.setLayout(
             (context.resources.displayMetrics.widthPixels),
-            (context.resources.displayMetrics.heightPixels) // 높이도 전체 화면에 맞추기
+            dialogHeight
         )
     }
-
 
     private fun showDownloadDialog(context: Context, imageUrl: String) {
         val dialogBuilder = AlertDialog.Builder(context)

--- a/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
@@ -4,6 +4,8 @@ import android.app.Dialog
 import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.os.Environment
 import android.provider.MediaStore
@@ -126,6 +128,7 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
             })
 
         dialog.setContentView(dialogView)
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
         dialog.show()
 
         val screenHeight = context.resources.displayMetrics.heightPixels

--- a/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
+++ b/app/src/main/java/com/api/palette/ui/main/work/ImageAdapter.kt
@@ -106,12 +106,11 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
 
     private fun showZoomedImageDialog(context: Context, imageUrl: String) {
         val dialog = Dialog(context)
-
         val dialogView = LayoutInflater.from(context).inflate(R.layout.item_zoomed_image_dialog, null)
 
         val imageView = dialogView.findViewById<SubsamplingScaleImageView>(R.id.imageView)
 
-        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_CROP)
+        imageView.setMinimumScaleType(SubsamplingScaleImageView.SCALE_TYPE_CENTER_INSIDE) // 스케일링 변경
 
         Glide.with(context)
             .asBitmap()
@@ -131,9 +130,10 @@ class ImageAdapter(private var images: MutableList<String>) : RecyclerView.Adapt
 
         dialog.window?.setLayout(
             (context.resources.displayMetrics.widthPixels),
-            ViewGroup.LayoutParams.WRAP_CONTENT
+            (context.resources.displayMetrics.heightPixels) // 높이도 전체 화면에 맞추기
         )
     }
+
 
     private fun showDownloadDialog(context: Context, imageUrl: String) {
         val dialogBuilder = AlertDialog.Builder(context)

--- a/app/src/main/res/layout/fragment_change_password.xml
+++ b/app/src/main/res/layout/fragment_change_password.xml
@@ -44,7 +44,9 @@
                 android:layout_marginTop="50dp"
                 android:hint="현재 비밀번호"
                 android:textColorHint="@color/semiLightGray"
-                app:hintTextColor="@color/primaryColor">
+                app:hintTextColor="@color/primaryColor"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/semiLightGray">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/etBeforePassword"
@@ -53,7 +55,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:textColor="@color/black"
                     android:textColorHint="@color/semiLightGray"
-                    android:inputType="textEmailAddress"
+                    android:inputType="textPassword"
                     android:textColorHighlight="@color/lightBlue"
                     android:textCursorDrawable="@drawable/cursor_drawable"/>
 
@@ -62,10 +64,12 @@
             <com.google.android.material.textfield.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="50dp"
                 android:hint="변경할 비밀번호"
                 android:textColorHint="@color/semiLightGray"
-                app:hintTextColor="@color/primaryColor">
+                app:hintTextColor="@color/primaryColor"
+                android:layout_marginTop="20dp"
+                app:endIconMode="password_toggle"
+                app:endIconTint="@color/semiLightGray">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/etAfterPassword"
@@ -74,7 +78,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:textColor="@color/black"
                     android:textColorHint="@color/semiLightGray"
-                    android:inputType="textEmailAddress"
+                    android:inputType="textPassword"
                     android:textColorHighlight="@color/lightBlue"
                     android:textCursorDrawable="@drawable/cursor_drawable"/>
 

--- a/app/src/main/res/layout/fragment_chatting.xml
+++ b/app/src/main/res/layout/fragment_chatting.xml
@@ -42,60 +42,6 @@
             app:layout_constraintTop_toBottomOf="@+id/chattingAppBarLayout"
             android:layout_marginBottom="16dp"/>
 
-        <Button
-            android:id="@+id/regenButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="다시 생성하기"
-            android:textSize="16sp"
-            android:textColor="#FFFFFF"
-            android:background="@drawable/bac_regen_button"
-            android:paddingHorizontal="24dp"
-            android:paddingVertical="12dp"
-            android:layout_marginBottom="16dp"
-            android:elevation="4dp"
-            android:layout_gravity="center"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            android:visibility="gone"/>
-
-        <LinearLayout
-            android:id="@+id/positionBox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:layout_marginTop="16dp"
-            android:paddingHorizontal="16dp"
-            android:paddingVertical="8dp"
-            app:layout_constraintBottom_toTopOf="@id/chatUserInputBox"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:background="@drawable/bac_position"
-            android:gravity="center"
-            android:visibility="gone">
-            <TextView
-                android:id="@+id/position_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="앞에 있는 사용자 : "
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:fontFamily="@font/pretendard_medium"
-                app:layout_constraintBottom_toTopOf="@id/chatUserInputBox"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"/>
-
-            <TextView
-                android:id="@+id/current_position_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="2"
-                android:textSize="16sp"
-                android:textColor="@color/primaryColor"
-                android:fontFamily="@font/pretendard_bold"/>
-        </LinearLayout>
-
         <LinearLayout
             android:id="@+id/chatUserInputBox"
             android:layout_width="match_parent"
@@ -103,7 +49,61 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:gravity="center">
+
+            <LinearLayout
+                android:id="@+id/positionBox"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="8dp"
+                app:layout_constraintBottom_toTopOf="@id/chatUserInputBox"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:background="@drawable/bac_position"
+                android:gravity="center"
+                android:visibility="gone">
+                <TextView
+                    android:id="@+id/position_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="앞에 있는 사용자 : "
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:fontFamily="@font/pretendard_medium"
+                    app:layout_constraintBottom_toTopOf="@id/chatUserInputBox"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <TextView
+                    android:id="@+id/current_position_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="2"
+                    android:textSize="16sp"
+                    android:textColor="@color/primaryColor"
+                    android:fontFamily="@font/pretendard_bold"/>
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/regenButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="다시 생성하기"
+                android:layout_marginHorizontal="20dp"
+                android:textSize="16sp"
+                android:textColor="#FFFFFF"
+                android:background="@drawable/bac_regen_button"
+                android:paddingHorizontal="24dp"
+                android:paddingVertical="12dp"
+                android:layout_marginBottom="16dp"
+                android:elevation="4dp"
+                android:layout_gravity="center"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:visibility="gone"/>
 
             <LinearLayout
                 android:id="@+id/chattingSelectLayout"

--- a/app/src/main/res/layout/item_zoomed_image_dialog.xml
+++ b/app/src/main/res/layout/item_zoomed_image_dialog.xml
@@ -1,10 +1,10 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"> <!-- 높이 변경 -->
+    android:layout_height="wrap_content">
 
     <com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" /> <!-- 높이 변경 -->
+        android:layout_height="match_parent" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/item_zoomed_image_dialog.xml
+++ b/app/src/main/res/layout/item_zoomed_image_dialog.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
+        android:id="@+id/imageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_zoomed_image_dialog.xml
+++ b/app/src/main/res/layout/item_zoomed_image_dialog.xml
@@ -1,11 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent"> <!-- 높이 변경 -->
 
     <com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="match_parent" /> <!-- 높이 변경 -->
 
 </FrameLayout>

--- a/app/src/main/res/layout/item_zoomed_image_dialog.xml
+++ b/app/src/main/res/layout/item_zoomed_image_dialog.xml
@@ -1,6 +1,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="15dp">
 
     <com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
         android:id="@+id/imageView"


### PR DESCRIPTION
### 다른 문제
해결하는 도중 다이얼로그의 height를 핸드폰 크기 * 0.8로 설정한 부분이 있는데, 그것 때문에 작은 이미지는 이미지 바깥을 클릭해도 투명 다이얼로그가 남아있어 다이얼로그가 꺼지지 않는 문제가 추가로 발생했습니다. 허허...